### PR TITLE
Lock fix in MessageReliabilityTrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed lock mechanism in MessageReliabilityTrait
 
 ## [1.3.0] - 2025-04-09
 ### Added

--- a/src/Driver/MessageReliabilityTrait.php
+++ b/src/Driver/MessageReliabilityTrait.php
@@ -182,7 +182,16 @@ trait MessageReliabilityTrait
             $this->monitorHashRedisKey,
         );
 
-        if ($this->redis->setex($lockKey, MessageReliabilityInterface::LOCK_TTL, $this->myIdentifier)) {
+        $locked = (bool)$this->redis->rawCommand(
+            'SET',
+            $lockKey,
+            $this->myIdentifier,
+            'NX',
+            'EX',
+            MessageReliabilityInterface::LOCK_TTL,
+        );
+
+        if ($locked) {
             try {
                 $start = hrtime(true);
 


### PR DESCRIPTION
changed redis `SETEX` for `SET ... NX EX` to in MessageReliabilityTrait to implement real locking